### PR TITLE
修复弹出层在某些情况下调整层大小的时候出现层内容高度不会随之改变的问题

### DIFF
--- a/src/lay/modules/layer.js
+++ b/src/lay/modules/layer.js
@@ -796,7 +796,7 @@ layer.style = function(index, options, limit){
   }
   
   layero.css(options);
-  btnHeight = layero.find('.'+doms[6]).outerHeight();
+  btnHeight = layero.find('.'+doms[6]).outerHeight() || 0;
   
   if(type === ready.type[2]){
     layero.find('iframe').css({


### PR DESCRIPTION
799行处的`btnHeight = layero.find('.'+doms[6]).outerHeight();`在某些特定的情况下，`btnHeight`的值会是`undefined`，从而导致高度没有更新成功，应该是外部原因，使用的时候刚好遇到了。
其他地方的`layero.find('.'+doms[6]).outerHeight()`操作都后面都有`|| 0`操作，而这里没有，显然是漏掉了，导致出现Bug。